### PR TITLE
Fix broken privacyguides link

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -1376,7 +1376,7 @@
                   </div>
                 </div></li>
             </a>
-            <a href="https://www.privacyguides.org/providers/email/#selfhosting">
+            <a href="https://www.privacyguides.org/email/#self-hosting-email">
               <li><i style="background:#2c3e50">
                   <img src="./assets/logos/selfhost.svg" alt="selfhost">
                 </i> &nbsp;&nbsp;


### PR DESCRIPTION
Updated the link with info on self-hosting email from Privacy Guides, which broke following the PG website redesign