### PR TITLE
Create mta-sts.txt

### DIFF
--- a/mta-sts/.well-known/mta-sts.txt
+++ b/mta-sts/.well-known/mta-sts.txt
@@ -1,0 +1,5 @@
+version: STSv1
+mode: enforce
+mx: mail.protonmail.ch
+mx: mailsec.protonmail.ch
+max_age: 604800


### PR DESCRIPTION
MTA-STS (#11) can be enabled by:

1. Setting up an `mta-sts` subdomain at Orange and pointing it to this new `/mta-sts` folder.
2. Setting up an `_mta-sts` TXT record: `v=STSv1; id=20230524000000`
3. Merging this PR.