### PR TITLE
List system fonts instead of using system-ui

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -13,6 +13,7 @@
   --pink: #B451AB;
   --green: #369A77;
   --green-d: #024c32;
+  --system-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
 }
 
 /* --------------- Simple reset --------------- */
@@ -23,7 +24,7 @@
 
 html,
 body {
-  font-family: system-ui;
+  font-family: var(--system-ui);
   margin: 0;
   padding: 0;
   color: #fff;


### PR DESCRIPTION
Using `system-ui` is [discouraged](https://infinnie.github.io/blog/2017/systemui.html) because it does not work as expected when some non-English languages are selected in Windows.