### PR TITLE
Enable PGP WKD

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -4,8 +4,11 @@ https://discord.techlore.tech/* https://discord.com/servers/techlore-42233227432
 # MTA-STS
 https://mta-sts.techlore.tech/* /mta-sts.txt 200!
 
-# VPN Chart Redirect
-/vpnchart.html /vpn 301
-/vpnchart /vpn 301
-/affiliations /affiliates 301
+# PGP Web Key Directory
+/.well-known/openpgpkey/* https://openpgpkey.protonmail.com/.well-known/openpgpkey/techlore.tech/:splat 200!
+
+# Other Redirects
+/vpnchart.html /vpn
+/vpnchart /vpn
+/affiliations /affiliates
 /sponsors https://discuss.techlore.tech/pub/sponsors


### PR DESCRIPTION
Makes the public key for @techlore.tech emails available via Proton's web key directory.

e.g. contact@techlore.tech would be available at [https://techlore.tech/.well-known/openpgpkey/hu/dj3498u4hyyarh35rkjfnghbjxug6b19?l=contact](https://deploy-preview-62--techlore.netlify.app/.well-known/openpgpkey/hu/dj3498u4hyyarh35rkjfnghbjxug6b19?l=contact)