### PR TITLE
Fix Non-Affiliate links on Affiliate page

### DIFF
--- a/affiliates.html
+++ b/affiliates.html
@@ -321,7 +321,7 @@
           <h5 id="collaboration">Collaboration & Files</h5>
           <a class="btnA" href="https://amzn.to/3qYYuo3">Amazon🌟</a>
           <a class="btnA" href="https://howl.me/cj7claO9VLo">Newegg🌟</a>
-          <a class="btnA" href="https://protonmail.com/">Non-Affiliate</a><br><br>
+          <a class="btnA" href="https://www.synology.com/en-us/products/store">Non-Affiliate</a><br><br>
         </div>
       </div>
       <div class="col-4">
@@ -370,7 +370,7 @@
           <h5 id="Shotgun Mic">Shotgun Mic</h5>
           <a class="btnA" href="https://amzn.to/3PN13DR">Amazon🌟</a>
           <a class="btnA" href="https://howl.me/cj7amiPhNkt">Newegg🌟</a>
-          <a class="btnA" href="https://protonmail.com/">Non-Affiliate</a><br><br>
+          <a class="btnA" href="https://www.sennheiser.com/en-us/catalog/products/microphones/mke-600/mke-600-505453">Non-Affiliate</a><br><br>
         </div>
       </div>
       <div class="col-4">
@@ -380,7 +380,7 @@
           <h5 id="USB Mic">USB Mic</h5>
           <a class="btnA" href="https://amzn.to/44d04S7">Amazon🌟</a>
           <a class="btnA" href="https://howl.me/cj7azQ3Trxd">Newegg🌟</a>
-          <a class="btnA" href="https://protonmail.com/">Non-Affiliate</a><br><br>
+          <a class="btnA" href="https://www.logitechg.com/en-us/products/streaming-gear/yeti-premium-usb-microphone.988-000103.html">Non-Affiliate</a><br><br>
         </div>
       </div>
       <div class="col-4">

--- a/affiliates.html
+++ b/affiliates.html
@@ -321,7 +321,7 @@
           <h5 id="collaboration">Collaboration & Files</h5>
           <a class="btnA" href="https://amzn.to/3qYYuo3">Amazon🌟</a>
           <a class="btnA" href="https://howl.me/cj7claO9VLo">Newegg🌟</a>
-          <a class="btnA" href="https://www.synology.com/en-us/products/store">Non-Affiliate</a><br><br>
+          <a class="btnA" href="https://www.synology.com/en-us/products/DS923+">Non-Affiliate</a><br><br>
         </div>
       </div>
       <div class="col-4">
@@ -341,7 +341,7 @@
           <h5 id="Lens">Lens</h5>
           <a class="btnA" href="https://amzn.to/44BTuEg">Amazon🌟</a>
           <a class="btnA" href="https://howl.me/cj697dVmQbQ">Newegg🌟</a>
-          <a class="btnA" href="https://protonmail.com/">Non-Affiliate</a><br><br>
+          <a class="btnA" href="https://electronics.sony.com/imaging/lenses/all-e-mount/p/sel35f18f">Non-Affiliate</a><br><br>
         </div>
       </div>
       <div class="col-4">
@@ -351,7 +351,7 @@
           <h5 id="Lens">Lens</h5>
           <a class="btnA" href="https://amzn.to/3D0JlW6">Amazon🌟</a>
           <a class="btnA" href="https://howl.me/cj7acIrbVBv">Newegg🌟</a>
-          <a class="btnA" href="https://protonmail.com/">Non-Affiliate</a><br><br>
+          <a class="btnA" href="https://electronics.sony.com/imaging/lenses/full-frame-e-mount/p/sel2470z">Non-Affiliate</a><br><br>
         </div>
       </div>
       <div class="col-4">


### PR DESCRIPTION
Some of the items listed in the affiliates page have the non-affiliate link set to https://protonmail.com instead of the correct non-affiliate website.

I have fixed this in this pull request.