### PR TITLE
Remove mention of enabling GitHub Pages feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ This website uses HTML, CSS and vanilla Javascript. It doesn't have any dependen
 **To contribute to our VPN Toolkit, [visit here!](/assets/vpn)**
 
 #### Do you want to improve the project? 
-- Fork this repository 
-- Enable the Github Pages feature
+- Fork this repository
 - Edit the project with the improvements and features 
 - Make a pull request with detailed changes 
 - Wait for our team to evaluate the changes 


### PR DESCRIPTION
Hello, 

I don't think we should now tell people to actually "enable" the GitHub Pages. At least, for me, it isn't needed.

Thanks.