### PR TITLE
Update old links

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -263,7 +263,7 @@
                   </div>
                 </li>
               </a>
-              <a href="https://www.mozilla.org">
+              <a href="https://firefox.com">
               <li><i style="background:#FF7139">
                   <img src="./assets/logos/firefox.svg" alt="firefox"></i>&nbsp;&nbsp;
                   <div class="tooltip">
@@ -308,7 +308,7 @@
             <a href="#android-browsers"><u>Android Web Browsers</u></a>
           </div>
           <ul>
-            <a href="https://play.google.com/store/apps/details?id=org.torproject.torbrowser">
+            <a href="https://www.torproject.org/download/#android">
               <li><i style="background:#7E4798">
                   <img src="./assets/logos/torbrowser.svg" alt="tor">
                 </i>&nbsp;&nbsp;
@@ -336,7 +336,7 @@
                     </div>
                   </div></li>
             </a>
-            <a href="https://play.google.com/store/apps/details?id=org.mozilla.firefox">
+            <a href="https://firefox.com">
               <li><i style="background:#FF7139">
                   <img src="./assets/logos/firefox.svg" alt="firefox"></i>&nbsp;&nbsp;
                   <div class="tooltip">
@@ -411,7 +411,7 @@
                     </div>
                   </div> </li>
             </a>
-            <a href="https://apps.apple.com/us/app/firefox-private-safe-browser/id989804926">
+            <a href="https://firefox.com">
               <li><i style="background:#FF7139">
                   <img src="./assets/logos/firefox.svg" alt="firefox"></i>&nbsp;&nbsp;
                   <div class="tooltip">
@@ -756,7 +756,7 @@
                     </div>
                   </div></li>
             </a>
-            <a href="https://auroraoss.com/downloads.php">
+            <a href="https://auroraoss.com/">
               <li><i style="background:#6B62FF">
                   <img src="./assets/logos/aurora.svg" alt="aurora"></i>&nbsp;&nbsp;
                   <div class="tooltip">
@@ -828,7 +828,7 @@
                   </div>
                 </div></li>
               </a>
-              <a href="https://getfedora.org/">
+              <a href="https://fedoraproject.org/">
               <li><i style="background:#294172">
                   <img src="./assets/logos/fedora.svg" alt="fedora">
                 </i> &nbsp;&nbsp;
@@ -920,7 +920,7 @@
                     </div>
                   </div></li>
             </a>
-            <a href="https://tails.boum.org/">
+            <a href="https://tails.net/">
               <li><i style="background:#56347C">
                   <img src="./assets/logos/tails.svg" alt="tails"></i>&nbsp;&nbsp;
                   <div class="tooltip">
@@ -1032,7 +1032,7 @@
             <a href="#search"><u>Search Engines</u></a>
           </div>
           <ul>
-            <a href="https://github.com/searxng/searxng">
+            <a href="https://docs.searxng.org/">
               <li><i style="background:#FFFFFF">
                   <img src="./assets/logos/searxng.svg" alt="searxng">
                 </i> &nbsp;&nbsp;


### PR DESCRIPTION
Just had a look through the resources and there are a few old links that need updating:

- Tails has moved from tails.boum.org to tails.net

More details here: https://tails.net/news/new_domain/index.en.html

- Fedora has moved from getfedora.org to fedoraproject.org

More details here: https://discussion.fedoraproject.org/t/its-time-to-update-the-main-fedora-website/30154

- AuroraOSS \download.php page isn’t required anymore

- Android link for Tor Browser links to the Google Play store there is now a page on the Tor Browser website that has APK links and links to the F-Droid and Google Play.

- Changed all the Firefox links firefox.com which redirects to corresponding platforms download page.

- Updated SearXNG page from the GitHub page to their dedicated website that has documentation.
