### PR TITLE
Fix bug where drop down navbar doesn't display properly

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -782,7 +782,7 @@ footer {
 
 /* ------------- Media  ------------- */
 
-@media (min-width: 1301px) {
+@media (min-width: 1230px) {
 
   nav ul li {
     display: inline-block;


### PR DESCRIPTION
How it currently displays between 1230-1300px screen width:
![Screenshot 2024-04-09 at 6 18 55 PM](https://github.com/techlore/website/assets/154663344/56dea40f-1e36-4c78-a4c0-2666f38e8bac)

How it should display:
![Screenshot 2024-04-09 at 6 20 40 PM](https://github.com/techlore/website/assets/154663344/87ffb77f-6ba7-4c8c-8fd2-4c7d2b2db8b1)

Just required a small tweak to the CSS about when it switches to the correct navbar display.