### PR TITLE
Substitute Techlore Substack link for Techlore Blog link

### DIFF
--- a/goincognito.html
+++ b/goincognito.html
@@ -123,7 +123,7 @@
           </div>
           <div>
             <a class="btn" href="https://techlore.teachable.com/p/go-incognito">Enroll Now</a>
-                  <p>Note: Go Incognito v2 is being produced<a href="https://dispatch.techlore.tech/i/116795784/go-incognito-v"> now.</a> All premium students will be grandfathered into future versions of the project.</p>
+                  <p>Note: Go Incognito v2 is being produced<a href="https://blog.techlore.tech/go_incognito_v2/"> now.</a> All premium students will be grandfathered into future versions of the project.</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The Techlore Substack is now private and the Techlore blog is now hosted using Bear blog.

More information: https://discuss.techlore.tech/t/techlore-new-blog-and-new-podcast-provider/8689