### PR TITLE
Remove Merchandise link

### DIFF
--- a/goincognito.html
+++ b/goincognito.html
@@ -133,7 +133,6 @@
           <a target="_blank" href="https://github.com/techlore-official/go-incognito/blob/master/sources.md">Sources</a>
           <a target="_blank" href="https://github.com/techlore-official/go-incognito/blob/master/changes.md">Changelog</a>
           <a target="_blank" href="https://www.youtube.com/playlist?list=PL3KeV6Ui_4CayDGHw64OFXEPHgXLkrtJO">Behind the Scenes</a>
-          <a target="_blank" href="https://shop.techlore.tech/">Merchandise</a>
           <a target="_blank" href="support">Support Project</a>
         </div>
       </div>

--- a/goincognito.html
+++ b/goincognito.html
@@ -134,6 +134,7 @@
           <a target="_blank" href="https://github.com/techlore-official/go-incognito/blob/master/changes.md">Changelog</a>
           <a target="_blank" href="https://www.youtube.com/playlist?list=PL3KeV6Ui_4CayDGHw64OFXEPHgXLkrtJO">Behind the Scenes</a>
           <a target="_blank" href="support">Support Project</a>
+          <a target="_blank" href="about">About Techlore</a>
         </div>
       </div>
       <div class="_aos">


### PR DESCRIPTION
This pull request removes the link to the Techlore Spring store links because it is one of the inactive Techlore owned accounts, according to the following source.

Source: https://www.techlore.tech/about