### PR TITLE
Update Privacy Guides' VPN Breakdown link.html

### DIFF
--- a/vpn.html
+++ b/vpn.html
@@ -134,7 +134,7 @@
                 <a href="https://www.ivpn.net/blog/why-you-dont-need-a-vpn/">IVPN's Why you don't need a VPN</a>
               </li>
               <li>
-                <a href="https://www.privacyguides.org/providers/vpn/#info">Privacy Guides' VPN Breakdown</a>
+                <a href="https://www.privacyguides.org/en/vpn/">Privacy Guides' VPN Breakdown</a>
               </li>
             </ul>
           </p>


### PR DESCRIPTION
If the link I submitted in this pull request isn't the right one, maybe the link to the Privacy Guides' VPN Overview, part of the Privacy Guides' Knowledge base, is the link you are looking for.

The link I submitted: https://www.privacyguides.org/en/vpn/

The Privacy Guides' VPN Overview link: https://www.privacyguides.org/en/basics/vpn-overview/

Or maybe add both links to the FAQ with different descriptions, if both links are considered adequate and likely useful to the viewers of the Techlore VPN Toolkit.