### PR TITLE
Update the YouTube video linked to the Android browser recommendations

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -349,7 +349,7 @@
                     </div>
                   </div></li>
             </a>
-            <a href="https://youtu.be/-CDVNW2MD0g">
+            <a href="https://youtube.com/watch?v=s6jM5-d-jXc">
               <li><i style="background:#FF0000">
                   <img src="./assets/logos/youtube.svg" alt="youtube"></i>&nbsp;&nbsp;Choosing A Browser</li>
             </a>


### PR DESCRIPTION
The video this pull request adds to the website offers more up-to-date browser recommendations than the previous YouTube video.

Even thought the video added in this pull request also talks about iOS instead of being an Android-only video, I think that's a worth tradeoff for more up-to-date browser recommendations.