### PR TITLE
Add RSS feed page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -87,7 +87,6 @@ socials:
     facebook: "https://www.facebook.com/people/Techlore/61559410727510/"
     telegram: "https://t.me/techlorefeed"
     matrix: "https://matrix.to/#/%23techlore:matrix.org"
-    reddit: "https://www.reddit.com/r/techlore/"
   extra:
     linkedin: "https://www.linkedin.com/company/techloreinc/"
 forum:

--- a/_config.yml
+++ b/_config.yml
@@ -79,6 +79,7 @@ socials:
   links: # these links also appear in the "feature box" on the homepage amd in the footer
     youtube: "https://www.youtube.com/@techlore"
     mastodon: "https://social.lol/@techlore"
+    rss: "/rss"
     signal: "https://discuss.techlore.tech/t/signal-usernames-are-here-join-our-exclusive-signal-group/7640"
     twitter: "https://twitter.com/TechloreInc"
     bluesky: "https://bsky.app/profile/techlore.bsky.social"

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,29 @@
+---
+layout: default
+---
+{% include variables.html %}
+
+{% capture description %}
+{% if page.description %}
+{{ page.description | markdownify }}
+{% endif %}
+{% if page.description and page.date %}
+<br>
+{% endif %}
+{% if page.date %}
+<em>{% if page.author %}By: {{ page.author }} — {% endif %}{{ page.date }}</em>
+{% endif %}
+{% endcapture %}
+
+
+{% include c_sub-hero.html title=page.title perex=description %}
+
+<article class="post">
+
+  <div class="post-content container is-max-tablet {% if page.numbered_headings %}has-titles-counted{% endif %}">
+    <section>
+      {{ content }}
+    </section>
+  </div>
+
+</article>

--- a/privacy.md
+++ b/privacy.md
@@ -1,16 +1,9 @@
 ---
-layout: page
+layout: post
 title: "Privacy Policy"
 permalink: /privacy
+numbered_headings: true
 ---
-{% include variables.html %}
-{% include c_sub-hero.html title=page.title %}
-
-
-<section>
-	<div class="container is-max-tablet has-titles-counted">
-
-{% capture markdown_text %}
 Techlore, Inc. is committed to protecting the privacy of its users. Like everything we do, we've designed this policy to be simple and accessible to all. Unless otherwise indicated, it is applicable to any website that references the policy.
 
 “Service” refers to our services which can be accessed on our website at [https://www.techlore.tech](https://www.techlore.tech). The terms “we,” “us,” and “our” refer to Techlore, Inc. “You” refers to you, as a user of our services.
@@ -21,16 +14,15 @@ By accessing our website & Services, you accept our Privacy Policy and Terms of 
 
 Each time you visit our website, or use the Service, and any time you voluntarily provide us with information, you consent to our collection, use and disclosure of the information that you provide.
 
-
-## Information we colect
+## Information we collect
 
 **Our Goal Is To Not Know Who You Are**
 
 To protect our hinds, we will state: We may collect both “Non-Personal Information” and “Personal Information” about you.
 
 - “Non-Personal Information” includes information that cannot be directly used to personally identify you, such as basic browser information (Ex. Firefox on Linux) This is standard on most hosting services.
-- “Personal Information” includes information that can be used to personally identify you, such as your name and email address. This is never collected unless you optionally communicate with us by email or another contact method. We don't typically verify the information supplied, so you have every ability to use aliases when contacting us. We have several recommendations for aliasing services in our [resources](TODO: https://www.techlore.tech/resources#alias).
-- We do not utilize cookies, we don't track you through scripts, and we do not implement trackers on our website to analyze your behavior. The only exception to this is our YouTube content embedded on this website which may have the indirect ability of tracking users. We recommend using browser tools to block trackers that may be used by the embedded tool if this concerns you - or alternatively you may disable Javascript, though this may break some other tools on our site.
+- “Personal Information” includes information that can be used to personally identify you, such as your name and email address. This is never collected unless you optionally communicate with us by email or another contact method. We don't typically verify the information supplied, so you have every ability to use aliases when contacting us. We have several recommendations for aliasing services in our [resources]({% link resources.html %}#aliasing).
+- We do not utilize cookies, we don't track you through scripts, and we do not implement trackers on our website to analyze your behavior. The only exception to this is our YouTube content embedded on this website which may have the indirect ability of tracking users. We recommend using browser tools to block trackers that may be used by the embedded tool if this concerns you - or alternatively you may disable JavaScript, though this may break some other tools on our site.
 
 ## How we use and share information
 
@@ -39,7 +31,7 @@ To protect our hinds, we will state: We may collect both “Non-Personal Informa
 - In rare scenarios, a third-party may be involved in handling your information to provide a Service. Generally, these third-parties will only collect, use and disclose your information to the extent necessary to allow them to perform the required services. We always attempt to offer safer alternatives to users when available.
 - It's important to mention certain third-party service providers, such as payment processors, have their own privacy policies we have no control over. We recommend you read their privacy policies so that you can understand the manner in which your Personal Information will be handled by such providers. We aim to offer more private alternatives to users when the option is available.
 
-**In regards to how your information is used, the answer is simply to perform the Service you require. Unlike most companies, we don't have anything to gain from your data.**
+**In regard to how your information is used, the answer is simply to perform the Service you require. Unlike most companies, we don't have anything to gain from your data.**
 
 ## How we protect information
 
@@ -65,11 +57,6 @@ Based upon the Personal Information that you provide us, we may communicate with
 
 If you have any questions regarding this Privacy Policy or the practices of this Site, please contact us by sending an email to [contact@techlore.tech](mailto:contact@techlore.tech)
 
-|   |
-|:-:|
-| **Last Updated: This Privacy Policy was last updated on Tue June 06 2023.** |
-{% endcapture %}
-{{ markdown_text | markdownify }}
+---
 
-	</div>
-</section>
+**Last Updated: This Privacy Policy was last updated on Tue June 06, 2023.**

--- a/rss.md
+++ b/rss.md
@@ -1,0 +1,28 @@
+---
+layout: post
+title: "Techlore RSS Feeds"
+permalink: /rss
+description: |
+  RSS is the cleanest method available for following Techlore. Follow any of the feeds below with your favorite feed reader!
+  To learn more about RSS check out [this guide](https://rss.com/blog/how-do-rss-feeds-work/).
+---
+
+## Techlore Feeds
+
+- [Primary Mastodon Feed](https://social.lol/@techlore.rss) - We post all major announcements (new videos, shows, and many other updates from ourselves and the community) here on Mastodon, so if you want a single place to stay informed about everything, this is it!
+- [Techlore Forum Feeds](https://discuss.techlore.tech/t/heres-how-to-use-rss-with-techlore-discussions/141)
+- [All Techlore Feeds](https://discuss.techlore.tech/t/introducing-techlore-feeds-reviving-twitter-telegram-matrix/4067)
+
+## Blog-Only Updates
+
+- [Techlore Blog RSS](https://blog.techlore.tech/feed/)
+
+## Video-Only Feeds
+
+- [YouTube](https://www.youtube.com/feeds/videos.xml?channel_id=UCs6KfncB4OV6Vug4o_bzijg)
+- [PeerTube](https://neat.tube/feeds/videos.xml?videoChannelId=172)
+
+## Audio-Only Feeds
+
+- [Techlore Talks Podcast](https://feeds.acast.com/public/shows/techlore)
+- [Surveillance Report Podcast](https://feeds.acast.com/public/shows/65e15188b8456c00169f4864)


### PR DESCRIPTION
- Brings back the [RSS](https://web.archive.org/web/20241126040015/techlore.tech/rss) feed page with minor updates (i.e. not linking to paywalled business insider)
- Fixes some Privacy Policy typos
- Adds a new "post.html" layout that the privacy policy and this RSS page both use. It makes it very easy for Henry or whomever to add simple new pages with only markdown. ([example](https://github.com/techlore/website/pull/145/files#diff-46d520da29befd78c0cf165b01d155dce452ec74cc4f24c0dd6a8dc61d6c7693))

**Preview:**

![image](https://github.com/user-attachments/assets/1844cacc-58e5-49c6-b689-c10bfb1567a3)
