### PR TITLE
Quick access buttons for the Resources page

### DIFF
--- a/_data/_en/content.yml
+++ b/_data/_en/content.yml
@@ -73,11 +73,21 @@ home:
 # -----------------------------------------
 # RESOURCES section and page
 #
-# Knowledgebase sources:   - text in `knowledgebase.yml`
+# Knowledgebase sources:   - text in `knowledgebase-text.yml`
 #                          - data in `/knowledgebase` folder
 #
+# subHeroButtons.class:    - based on Bulma classes (.is-primary, .is-success, .is-danger, .is-warning, .is-info)
 resources:
   title: "Resources"
+  subHeroButtons:
+    -
+      text: "Guides"
+      url: "#techlore-guides"
+      class: "is-danger"
+    -
+      text: "All resources"
+      url: "#all-resources"
+      class: "is-primary"
   section:
     title: "Useful resources"
     learn:

--- a/_includes/c_sub-hero.html
+++ b/_includes/c_sub-hero.html
@@ -1,13 +1,33 @@
+{% comment %}
+	SUB HERO -----------------------------------------
+	Info:
+			Displays title and description of the page and optional quick access buttons (#anchor)
+	Parameters:
+		- title (string)
+		- perex (string, optional)
+		- buttons (array, optional):	locally linked buttons with an arrow icon showed on the right side
+{% endcomment %}
 <div class="container">
-	<div class="sub-hero columns is-justify-content-space-between">
+	<div class="sub-hero columns is-justify-content-space-between is-align-items-flex-end">
 		<div class="column is-half-tablet">
-			{% if include.title %}
-				<h1 class="sub-hero__title">{{ include.title }}</h1>
-			{% endif %}
-			{% if include.perex %}
-				<p class="sub-hero__desc">{{ include.perex }}</p>
-			{% endif %}
+			{%- if include.title -%}
+				<h1 class="sub-hero__title">{{- include.title -}}</h1>
+			{%- endif %}
+			{%- if include.perex -%}
+				<p class="sub-hero__desc">{{- include.perex -}}</p>
+			{%- endif -%}
 		</div>
-		<div class="columm is-one-fifth-mobile"></div>
+		<div class="column is-half-tablet">
+			{%- if include.buttons -%}
+				<div class="sub-hero__buttons buttons">
+					{%- for button in include.buttons -%}
+						<a href="{{- button.url -}}" class="button is-large is-gap-1.5{{ button.class | prepend: " " }}">
+							{{- button.text -}}
+							{%- include e_render-svg-icon.html icon="arrow-down" inline=true dimension=25 classes="icon" -%}
+						</a>
+					{%- endfor -%}
+				</div>
+			{%- endif -%}
+		</div>
 	</div>
 </div>

--- a/_sass/_sub-hero.scss
+++ b/_sass/_sub-hero.scss
@@ -19,3 +19,12 @@
 .sub-hero__desc {
 	text-wrap: balance;
 }
+
+.sub-hero__buttons {
+		justify-content: flex-end;
+
+	@media (max-width: $tablet) {
+		justify-content: center;
+		margin-top: var(--bulma-size-5);
+	}
+}

--- a/resources.html
+++ b/resources.html
@@ -2,11 +2,11 @@
 layout: page
 title: Resources
 permalink: /resources
-description: "Techlore's Privacy & Security recommendations based on our strict <strong>criteria</strong>. For further assistance, we suggest our <strong>Go Incognito</strong> course and our coaching. There are external resources at the bottom for more recommendations."
+description: "Techlore's Privacy & Security recommendations based on our strict <a href='https://discuss.techlore.tech/pub/criteria' target='_blank'>criteria</a>. For further assistance, we suggest our <a href='/goincognito'>Go Incognito</a> course and our coaching. There are <a href='#external-resources'>external resources</a> at the bottom for more recommendations."
 ---
-{% include variables.html %}
+{%- include variables.html -%}
 
-{% include c_sub-hero.html title=page.title perex=page.description %}
+{%- include c_sub-hero.html title=page.title perex=page.description buttons=t.resources.subHeroButtons -%}
 
 <section>
 	<div class="container">
@@ -114,7 +114,7 @@ description: "Techlore's Privacy & Security recommendations based on our strict 
 
 <section data-knowledgebase-navigation>
 	{% comment %} SOFTWARE, HW, APPS ============================================================= {% endcomment %}
-	<div class="container is-max-tablet">
+	<div class="container is-max-tablet" id="all-resources">
 		<div class="has-text-centered">
 			<h2>{{ kbtext.sections.software }}</h2>
 			<p>
@@ -381,7 +381,7 @@ description: "Techlore's Privacy & Security recommendations based on our strict 
 	</div>
 
 	{% comment %} EXTERNAL RESOURCES ============================================================= {% endcomment %}
-	<div class="container is-max-tablet mt-6">
+	<div class="container is-max-tablet mt-6" id="external-resources">
 		<div class="has-text-centered">
 			<h2>{{ kbtext.sections.external-resources }}</h2>
 			<p>


### PR DESCRIPTION
### NEW
- Quick access buttons for the _Resources_ page
<img width="1427" alt="image" src="https://github.com/user-attachments/assets/1560b518-d8c7-4003-83da-9805f40c5d57">

### FIX
- added proper links to the _Resources_ page description