### PR TITLE
FIX - Knowledge base

### DIFF
--- a/_data/_en/knowledgebase/other-services/cloud.yml
+++ b/_data/_en/knowledgebase/other-services/cloud.yml
@@ -52,6 +52,22 @@ data:
     labels:
       official: "https://cryptomator.org/"
     color: "#ffffff"
+  -
+    name: "OnionShare"
+    desc: "OnionShare allows users to share files, websites, chats, and more over the Tor network directly from their system with no central parties for absolute safety."
+    tags: ["Open Source", "Desktop"]
+    labels:
+      official: "https://onionshare.org/"
+    color: "#4E0D4E"
+    favorite: true
+  -
+    name: "Syncthing"
+    desc: "Syncthing allows users to easily sync files between devices without needing to upload them to the internet."
+    tags: ["Open Source", "All devices"]
+    labels:
+      official: "https://syncthing.net/"
+    color: "#1aa1d4"
+    favorite: true
 related:
   -
     title: "Best Cloud Storage"

--- a/_data/_en/knowledgebase/other-services/other-tools.yml
+++ b/_data/_en/knowledgebase/other-services/other-tools.yml
@@ -65,22 +65,6 @@ data:
       official: "https://objective-see.org/"
     color: "#ffffff"
     favorite: true
-  -
-    name: "OnionShare"
-    desc: "OnionShare allows users to share files, websites, chats, and more over the Tor network directly from their system with no central parties for absolute safety."
-    tags: ["Open Source", "Desktop"]
-    labels:
-      official: "https://onionshare.org/"
-    color: "#4E0D4E"
-    favorite: true
-  -
-    name: "Syncthing"
-    desc: "Syncthing allows users to easily sync files between devices without needing to upload them to the internet."
-    tags: ["Open Source", "All devices"]
-    labels:
-      official: "https://syncthing.net/"
-    color: "#1aa1d4"
-    favorite: true
 related:
   -
     title: "Big Ass Data Broker Opt-Out List"

--- a/resources.html
+++ b/resources.html
@@ -344,15 +344,6 @@ description: "Techlore's Privacy & Security recommendations based on our strict 
 		{% include c_knowledgebase.html title=title data=data related=relatedLinks %}
 	</div>
 
-	<!-- Networking -->
-	<div class="container mt-6" data-knowledgebase-section>
-		{% assign title = kbtext.categories.networking %}
-		{% assign data = site.data._en.knowledgebase.other-services.networking.data %}
-		{% assign relatedLinks = site.data._en.knowledgebase.other-services.networking.related %}
-
-		{% include c_knowledgebase.html title=title data=data related=relatedLinks %}
-	</div>
-
 	<!-- Other tools -->
 	<div class="container mt-6" data-knowledgebase-section>
 		{% assign title = kbtext.categories.other-tools %}


### PR DESCRIPTION
### FIX
- OrionShare and Syncthing moved from _Other tools_ to _Cloud_
- Removed empty _Networking_ category