### PR TITLE
Change URLs for Desktop OS in the SPA quiz

### DIFF
--- a/_data/_en/spa-quiz.yml
+++ b/_data/_en/spa-quiz.yml
@@ -216,7 +216,7 @@ data:
         slide: 3
         button:
           text: "Desktop OS"
-          url: "desktop"
+          url: "desktop-operating-systems"
       -
         answer: "Delete file metadata & EXIF"
         slide: 3
@@ -261,7 +261,7 @@ data:
         slide: 2
         button:
           text: "Desktop OS"
-          url: "desktop"
+          url: "desktop-operating-systems"
       -
         answer: "Shop online and in-person privately"
         slide: 2


### PR DESCRIPTION
I recently noticed that the "more information" links in the SPA quiz for the Desktop OS was linking to `#desktop`, but the resource is called `#desktop-operating-systems`.  So I changed the URL in the `spa-quiz.yml` file.