### PR TITLE
New page titles + small FIX

### DIFF
--- a/_includes/c_sub-hero.html
+++ b/_includes/c_sub-hero.html
@@ -11,8 +11,22 @@
 	<div class="sub-hero columns is-justify-content-space-between is-align-items-flex-end">
 		<div class="column is-half-tablet">
 			{%- if include.title -%}
-				<h1 class="sub-hero__title">{{- include.title -}}</h1>
+				{% assign delimiter = "|" %}
+
+				{% if include.title contains delimiter %}
+					{% assign splitTitle = include.title | split: delimiter %}
+
+					<h1 class="sub-hero__title">
+						{{- splitTitle[0] -}}
+						<span class="sub-hero__tagline">{{- splitTitle[1] -}}</span>
+					</h1>
+
+				{% else %}
+					<h1 class="sub-hero__title">{{- include.title -}}</h1>
+
+				{% endif %}
 			{%- endif %}
+
 			{%- if include.perex -%}
 				<p class="sub-hero__desc">{{- include.perex -}}</p>
 			{%- endif -%}

--- a/_sass/_sub-hero.scss
+++ b/_sass/_sub-hero.scss
@@ -4,6 +4,8 @@
 
 .sub-hero__title {
 	position: relative;
+	display: flex;
+	flex-direction: column;
 
 	&:after {
 		content: '';
@@ -14,6 +16,12 @@
 		translate: 0 var(--bulma-size-5);
 		border-radius: 100vmax;
 	}
+}
+
+.sub-hero__tagline {
+	font-size: var(--bulma-size-2);
+	color: var(--bulma-primary);
+	margin-top: calc(var(--bulma-size-5) * .5);
 }
 
 .sub-hero__desc {

--- a/videos.html
+++ b/videos.html
@@ -20,7 +20,7 @@ sitemap:
 				{% assign sortedVideosLatest = site.data._en.forum.latest-techlore-videos | sort: 'originallyPublishedAt' | reverse %}
 				{% for video in sortedVideosLatest limit: 3 %}
 					{% assign link = video.url %}
-					{% assign thumbnail = video.previewPath | prepend: "http://techlore.tv" %}
+					{% assign thumbnail = video.previewPath | prepend: "https://techlore.tv" %}
 					{% assign duration = video.duration | format_duration %}
 
 					{%- include c_video.html


### PR DESCRIPTION
### New page titles
- If the title contains `|`, it will show the part after it as the blue tagline. Otherwise, it will just display the title.

<img width="685" alt="image" src="https://github.com/user-attachments/assets/950de1e6-9c81-4fab-96b9-5b42d95ea2e4" />

### FIX
`http` --> `https` in `video.html`